### PR TITLE
Fixed overflowing card items in Firefox

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -7,6 +7,7 @@
 
   display: grid;
   grid-template-rows: 150px auto auto 1fr 20px;
+  grid-template-columns: minmax(0, 1fr);
   justify-items: center;
   align-items: center;
   gap: 15px;


### PR DESCRIPTION
Card grid items are overflowing in firefox (and I believe it is happening to other browsers too).

## Screenshot from Firefox (v139.0.1)
![Image](https://github.com/user-attachments/assets/66c07592-1d83-4e67-afe9-f5f1af107943)

## Problem Cause
No width was specified to the grid column. Hence it is up to the browser to use its default value which does not work well all the time.

## Solution
Add this css rule to the card.css file:
grid-template-columns: minmax(0, 1fr);